### PR TITLE
Add Status Cycling, Server Data, and more

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>games.negative.framework</groupId>
             <artifactId>discord-framework</artifactId>
-            <version>1.0.0-ALPHA-4</version>
+            <version>1.0.0-ALPHA-6</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/bot/tymebot/Bot.java
+++ b/src/main/java/bot/tymebot/Bot.java
@@ -4,6 +4,7 @@ import bot.tymebot.components.admin.CommandListGuilds;
 import bot.tymebot.components.admin.CommandListUsers;
 import bot.tymebot.components.admin.CommandReload;
 import bot.tymebot.components.guild.ServerJoinListener;
+import bot.tymebot.components.guild.ServerLeaveListener;
 import bot.tymebot.components.misc.CommandInfo;
 import bot.tymebot.components.server.ServerManager;
 import bot.tymebot.components.server.ServerManagerImpl;
@@ -82,7 +83,10 @@ public class Bot extends DiscordBot {
             registerServerCommand(parentServer, new CommandReload(this));
         }
         // listeners
-        builder.addEventListeners(new ServerJoinListener());
+        builder.addEventListeners(
+                new ServerJoinListener(this),
+                new ServerLeaveListener(this)
+        );
 
         jda = builder.build().awaitReady();
         initializeCommands(jda);

--- a/src/main/java/bot/tymebot/Bot.java
+++ b/src/main/java/bot/tymebot/Bot.java
@@ -2,6 +2,7 @@ package bot.tymebot;
 
 import bot.tymebot.components.admin.CommandListGuilds;
 import bot.tymebot.components.admin.CommandListUsers;
+import bot.tymebot.components.admin.CommandReload;
 import bot.tymebot.components.guild.ServerJoinListener;
 import bot.tymebot.components.misc.CommandInfo;
 import bot.tymebot.config.TymeConfig;
@@ -69,6 +70,10 @@ public class Bot extends DiscordBot {
         registerGlobalCommand(new CommandInfo());
         registerGlobalCommand(new CommandListUsers());
 
+        String parentServer = config.getParentServer();
+        if (parentServer != null) {
+            registerServerCommand(parentServer, new CommandReload(this));
+        }
         // listeners
         builder.addEventListeners(new ServerJoinListener());
 

--- a/src/main/java/bot/tymebot/Bot.java
+++ b/src/main/java/bot/tymebot/Bot.java
@@ -5,6 +5,8 @@ import bot.tymebot.components.admin.CommandListUsers;
 import bot.tymebot.components.admin.CommandReload;
 import bot.tymebot.components.guild.ServerJoinListener;
 import bot.tymebot.components.misc.CommandInfo;
+import bot.tymebot.components.server.ServerManager;
+import bot.tymebot.components.server.ServerManagerImpl;
 import bot.tymebot.components.status.DiscordStatusRunnable;
 import bot.tymebot.config.TymeConfig;
 import com.google.gson.Gson;
@@ -38,6 +40,9 @@ public class Bot extends DiscordBot {
     private final JDA jda;
     @Getter
     private TymeConfig config = null;
+
+    @Getter
+    private final ServerManager serverManager;
 
     @SneakyThrows
     public Bot() {
@@ -81,6 +86,7 @@ public class Bot extends DiscordBot {
 
         jda = builder.build().awaitReady();
         initializeCommands(jda);
+        serverManager = new ServerManagerImpl(this);
 
         // init config
         config.setDevIds(new String[]{"462296411141177364", "452520883194429440"});

--- a/src/main/java/bot/tymebot/Bot.java
+++ b/src/main/java/bot/tymebot/Bot.java
@@ -5,10 +5,12 @@ import bot.tymebot.components.admin.CommandListUsers;
 import bot.tymebot.components.admin.CommandReload;
 import bot.tymebot.components.guild.ServerJoinListener;
 import bot.tymebot.components.misc.CommandInfo;
+import bot.tymebot.components.status.DiscordStatusRunnable;
 import bot.tymebot.config.TymeConfig;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import games.negative.framework.discord.DiscordBot;
+import games.negative.framework.discord.runnable.Scheduler;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import net.dv8tion.jda.api.JDA;
@@ -84,6 +86,9 @@ public class Bot extends DiscordBot {
         config.setDevIds(new String[]{"462296411141177364", "452520883194429440"});
         saveConfig(file, gson);
         devIds = config.getDevIds();
+
+        Scheduler scheduler = getScheduler();
+        scheduler.run(new DiscordStatusRunnable(this), 1000L, 1000L * config.getDiscordStatusInterval());
     }
 
     @SneakyThrows

--- a/src/main/java/bot/tymebot/components/admin/CommandReload.java
+++ b/src/main/java/bot/tymebot/components/admin/CommandReload.java
@@ -1,0 +1,43 @@
+package bot.tymebot.components.admin;
+
+import bot.tymebot.Bot;
+import games.negative.framework.discord.command.SlashCommand;
+import games.negative.framework.discord.command.SlashInfo;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
+
+@SlashInfo(
+        name = "reload",
+        description = "Reloads the bot configuration."
+)
+public class CommandReload extends SlashCommand {
+
+    private final Bot bot;
+
+    public CommandReload(Bot bot) {
+        this.bot = bot;
+        setData(data -> {
+            data.setGuildOnly(true);
+            // Only visible to server administrators
+            data.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.ADMINISTRATOR));
+        });
+    }
+
+    @Override
+    public void onCommand(SlashCommandInteractionEvent event) {
+        Guild guild = event.getGuild();
+        if (guild == null)
+            return;
+        long start = System.currentTimeMillis();
+
+        bot.reloadConfig();
+
+        long end = System.currentTimeMillis();
+
+        long diff = Math.abs(end - start);
+        event.reply("Reloaded bot configuration in " + diff + "ms.")
+                .setEphemeral(true).queue();
+    }
+}

--- a/src/main/java/bot/tymebot/components/guild/ServerJoinListener.java
+++ b/src/main/java/bot/tymebot/components/guild/ServerJoinListener.java
@@ -1,5 +1,6 @@
 package bot.tymebot.components.guild;
 
+import bot.tymebot.Bot;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -8,11 +9,19 @@ import java.util.Objects;
 
 public class ServerJoinListener extends ListenerAdapter {
 
+    private final Bot bot;
+
+    public ServerJoinListener(Bot bot) {
+        this.bot = bot;
+    }
+
     @Override
     public void onGuildJoin(GuildJoinEvent e) {
         Guild guild = e.getGuild();
         Objects.requireNonNull(guild.getDefaultChannel()).asTextChannel().sendMessage("Thank you for inviting Tyme!");
 
         System.out.println("Tyme has joined %guild% (%guildid%) - %memberCount% members.".replace("%guild%", guild.getName()).replace("%guildid%", guild.getId().replace("%memberCount%", String.valueOf(guild.getMembers().size()))));
+
+        bot.getServerManager().addServer(guild);
     }
 }

--- a/src/main/java/bot/tymebot/components/guild/ServerLeaveListener.java
+++ b/src/main/java/bot/tymebot/components/guild/ServerLeaveListener.java
@@ -1,10 +1,17 @@
 package bot.tymebot.components.guild;
 
+import bot.tymebot.Bot;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.guild.GuildLeaveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
 public class ServerLeaveListener extends ListenerAdapter {
+
+    private final Bot bot;
+
+    public ServerLeaveListener(Bot bot) {
+        this.bot = bot;
+    }
 
     @Override
     public void onGuildLeave(GuildLeaveEvent e) {
@@ -14,5 +21,7 @@ public class ServerLeaveListener extends ListenerAdapter {
                 .replace("%guild%", guild.getName())
                 .replace("%guildid%", guild.getId()
                         .replace("%memberCount%", String.valueOf(guild.getMembers().size()))));
+
+        bot.getServerManager().removeServer(guild);
     }
 }

--- a/src/main/java/bot/tymebot/components/server/DiscordServer.java
+++ b/src/main/java/bot/tymebot/components/server/DiscordServer.java
@@ -1,0 +1,21 @@
+package bot.tymebot.components.server;
+
+import bot.tymebot.Bot;
+import net.dv8tion.jda.api.entities.Guild;
+import org.jetbrains.annotations.Nullable;
+
+public interface DiscordServer {
+
+    String getServerID();
+
+    @Nullable
+    default Guild getGuild() {
+        return Bot.getInstance().getJda().getGuildById(getServerID());
+    }
+
+    long getJoinDate();
+
+    boolean isBlacklisted();
+
+    void setBlacklisted(boolean blacklisted);
+}

--- a/src/main/java/bot/tymebot/components/server/DiscordServerImpl.java
+++ b/src/main/java/bot/tymebot/components/server/DiscordServerImpl.java
@@ -1,0 +1,37 @@
+package bot.tymebot.components.server;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class DiscordServerImpl implements DiscordServer {
+
+    @SerializedName("server-id")
+    private final String id;
+
+    @SerializedName("join-date")
+    private final long joinDate;
+
+    @SerializedName("blacklisted")
+    private boolean blacklisted;
+
+    @Override
+    public String getServerID() {
+        return id;
+    }
+
+    @Override
+    public long getJoinDate() {
+        return joinDate;
+    }
+
+    @Override
+    public boolean isBlacklisted() {
+        return blacklisted;
+    }
+
+    @Override
+    public void setBlacklisted(boolean blacklisted) {
+        this.blacklisted = blacklisted;
+    }
+}

--- a/src/main/java/bot/tymebot/components/server/ServerManager.java
+++ b/src/main/java/bot/tymebot/components/server/ServerManager.java
@@ -1,0 +1,27 @@
+package bot.tymebot.components.server;
+
+import net.dv8tion.jda.api.entities.Guild;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+public interface ServerManager {
+
+    Map<String, DiscordServer> getServers();
+
+    @Nullable
+    DiscordServer getServer(@NotNull String id);
+
+    default @Nullable DiscordServer getServer(@NotNull Guild guild) {
+        return getServer(guild.getId());
+    }
+
+    DiscordServer addServer(@NotNull Guild guild);
+
+    void removeServer(@NotNull String id);
+
+    default void removeServer(@NotNull Guild guild) {
+        removeServer(guild.getId());
+    }
+}

--- a/src/main/java/bot/tymebot/components/server/ServerManagerImpl.java
+++ b/src/main/java/bot/tymebot/components/server/ServerManagerImpl.java
@@ -1,0 +1,149 @@
+package bot.tymebot.components.server;
+
+import bot.tymebot.Bot;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import games.negative.framework.discord.runnable.RepeatingRunnable;
+import net.dv8tion.jda.api.entities.Guild;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.*;
+import java.util.Map;
+
+public class ServerManagerImpl implements ServerManager {
+
+    private final Map<String, DiscordServer> servers;
+    private final RepeatingRunnable autoSave;
+
+    public ServerManagerImpl(Bot bot) {
+        this.servers = loadServers();
+        this.autoSave = bot.getScheduler().run(new DiscordServerSaveRunnable(), 1000L * 15, 1000L * 60 * 30);
+    }
+
+    private Map<String, DiscordServer> loadServers() {
+        File dir = new File("servers");
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+
+        File[] files = dir.listFiles();
+        if (files == null || files.length == 0)
+            return Maps.newHashMap();
+
+        Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
+        Map<String, DiscordServer> servers = Maps.newHashMap();
+        for (File file : files) {
+            if (!file.getName().endsWith(".data")) continue;
+
+            try (Reader reader = new FileReader(file)) {
+                DiscordServer server = gson.fromJson(reader, DiscordServerImpl.class);
+                servers.put(server.getServerID(), server);
+            } catch (IOException e) {
+                System.out.println("Could not load data from file " + file.getName());
+                throw new RuntimeException(e);
+            }
+        }
+        System.out.println("Loaded " + servers.size() + " servers");
+        return servers;
+    }
+
+    @Override
+    public Map<String, DiscordServer> getServers() {
+        return servers;
+    }
+
+    @Nullable
+    @Override
+    public DiscordServer getServer(@NotNull String id) {
+        return servers.getOrDefault(id, null);
+    }
+
+    @Override
+    public DiscordServer addServer(@NotNull Guild guild) {
+        File dir = new File("servers");
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+
+        File file = new File(dir, guild.getId() + ".data");
+        if (file.exists()) {
+            try (Reader reader = new FileReader(file)) {
+                Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
+                DiscordServer server = gson.fromJson(reader, DiscordServerImpl.class);
+                servers.put(server.getServerID(), server);
+                return server;
+            } catch (IOException e) {
+                System.out.println("Could not load data from file " + file.getName());
+                throw new RuntimeException(e);
+            }
+        } else {
+            try {
+                file.createNewFile();
+            } catch (IOException e) {
+                System.out.println("Could not create file " + file.getName());
+                throw new RuntimeException(e);
+            }
+
+            DiscordServer server = new DiscordServerImpl(guild.getId(), System.currentTimeMillis());
+            servers.put(server.getServerID(), server);
+
+            Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
+            try (Writer writer = new FileWriter(file)) {
+                gson.toJson(server, writer);
+            } catch (IOException e) {
+                System.out.println("Could not save data to file " + file.getName());
+                throw new RuntimeException(e);
+            }
+
+            return server;
+        }
+    }
+
+    @Override
+    public void removeServer(@NotNull String id) {
+        File dir = new File("servers");
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+
+        File file = new File(dir, id + ".data");
+        if (file.exists()) {
+            file.delete();
+        }
+
+        servers.remove(id);
+    }
+
+    private class DiscordServerSaveRunnable implements RepeatingRunnable{
+
+        @Override
+        public void execute() {
+            File dir = new File("servers");
+            if (!dir.exists()) {
+                dir.mkdirs();
+            }
+
+            Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
+            for (DiscordServer server : servers.values()) {
+                File file = new File(dir, server.getServerID() + ".data");
+                if (!file.exists()) {
+                    try {
+                        file.createNewFile();
+                    } catch (IOException e) {
+                        System.out.println("Could not create file " + file.getName());
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                try (Writer writer = new FileWriter(file)) {
+                    gson.toJson(server, writer);
+                } catch (IOException e) {
+                    System.out.println("Could not save data to file " + file.getName());
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/bot/tymebot/components/server/ServerManagerImpl.java
+++ b/src/main/java/bot/tymebot/components/server/ServerManagerImpl.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import games.negative.framework.discord.runnable.RepeatingRunnable;
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -19,6 +20,18 @@ public class ServerManagerImpl implements ServerManager {
 
     public ServerManagerImpl(Bot bot) {
         this.servers = loadServers();
+
+        // If the bot was offline, and it had joined some servers,
+        // we need to make sure we account for that, so we are going to cycle
+        // through all current servers in JDA's cache and ensure they are all valid servers
+        // in our server data cache
+        JDA jda = bot.getJda();
+        for (Guild guild : jda.getGuilds()) {
+            if (servers.containsKey(guild.getId())) continue;
+
+            addServer(guild);
+        }
+
         this.autoSave = bot.getScheduler().run(new DiscordServerSaveRunnable(), 1000L * 15, 1000L * 60 * 30);
     }
 

--- a/src/main/java/bot/tymebot/components/status/DiscordStatus.java
+++ b/src/main/java/bot/tymebot/components/status/DiscordStatus.java
@@ -1,0 +1,6 @@
+package bot.tymebot.components.status;
+
+import net.dv8tion.jda.api.entities.Activity;
+
+public record DiscordStatus(Activity.ActivityType type, String text) {
+}

--- a/src/main/java/bot/tymebot/components/status/DiscordStatusRunnable.java
+++ b/src/main/java/bot/tymebot/components/status/DiscordStatusRunnable.java
@@ -1,0 +1,47 @@
+package bot.tymebot.components.status;
+
+import bot.tymebot.Bot;
+import bot.tymebot.config.TymeConfig;
+import bot.tymebot.core.TextBuilder;
+import bot.tymebot.core.Utils;
+import games.negative.framework.discord.runnable.RepeatingRunnable;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.managers.Presence;
+
+import java.util.List;
+
+public class DiscordStatusRunnable implements RepeatingRunnable {
+
+    private final Bot bot;
+    private int count = 0;
+
+    public DiscordStatusRunnable(Bot bot) {
+        this.bot = bot;
+    }
+
+    @Override
+    public void execute() {
+        JDA jda = bot.getJda();
+        TymeConfig config = bot.getConfig();
+
+        List<DiscordStatus> statuses = config.getStatuses();
+
+        DiscordStatus status = statuses.get(count);
+
+        String text = status.text();
+        String formatted = new TextBuilder(text)
+                .replace("%users%", Utils.decimalFormat(jda.getUsers().size()))
+                .replace("%guilds%", Utils.decimalFormat(jda.getGuilds().size())).build();
+
+        Presence presence = jda.getPresence();
+        presence.setActivity(Activity.of(status.type(), formatted));
+
+        count++;
+
+        if (count >= statuses.size())
+            count = 0;
+    }
+
+
+}

--- a/src/main/java/bot/tymebot/config/TymeConfig.java
+++ b/src/main/java/bot/tymebot/config/TymeConfig.java
@@ -10,6 +10,11 @@ public class TymeConfig {
     @SerializedName("token")
     private String botToken;
 
+    // Represents the Discord Server ID of the "Parent Server", you can
+    // consider this an "admin server"
+    @SerializedName("parent-server-id")
+    private String parentServer;
+
     @SerializedName("devIds")
     private String[] devIds;
 

--- a/src/main/java/bot/tymebot/config/TymeConfig.java
+++ b/src/main/java/bot/tymebot/config/TymeConfig.java
@@ -1,8 +1,13 @@
 package bot.tymebot.config;
 
 
+import bot.tymebot.components.status.DiscordStatus;
+import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
+import net.dv8tion.jda.api.entities.Activity;
+
+import java.util.List;
 
 @Data
 public class TymeConfig {
@@ -14,6 +19,19 @@ public class TymeConfig {
     // consider this an "admin server"
     @SerializedName("parent-server-id")
     private String parentServer;
+
+    // Determines how long (in seconds) the current discord status
+    // should show for before changing to the next one
+    @SerializedName("discord-status-interval")
+    private int discordStatusInterval = 10;
+
+    // A list of statuses to cycle through
+    @SerializedName("statuses")
+    private List<DiscordStatus> statuses = Lists.newArrayList(
+            new DiscordStatus(Activity.ActivityType.WATCHING, "over the server"),
+            new DiscordStatus(Activity.ActivityType.WATCHING, "%users% users"),
+            new DiscordStatus(Activity.ActivityType.WATCHING, "%guilds% guilds")
+    );
 
     @SerializedName("devIds")
     private String[] devIds;

--- a/src/main/java/bot/tymebot/core/TextBuilder.java
+++ b/src/main/java/bot/tymebot/core/TextBuilder.java
@@ -1,0 +1,18 @@
+package bot.tymebot.core;
+
+public class TextBuilder {
+
+    private final String text;
+
+    public TextBuilder(String text) {
+        this.text = text;
+    }
+
+    public TextBuilder replace(String key, String value) {
+        return new TextBuilder(text.replaceAll(key, value));
+    }
+
+    public String build() {
+        return text;
+    }
+}

--- a/src/main/java/bot/tymebot/core/Utils.java
+++ b/src/main/java/bot/tymebot/core/Utils.java
@@ -3,8 +3,17 @@ package bot.tymebot.core;
 import bot.tymebot.Bot;
 import lombok.experimental.UtilityClass;
 
+import java.text.DecimalFormat;
+
 @UtilityClass
 public class Utils {
+
+    private final DecimalFormat df;
+
+    static {
+        df = new DecimalFormat("###,###,###,###.##");
+    }
+
     public String getUptime() {
         long uptime = System.currentTimeMillis() - Bot.getStartTime();
         long uptimeSeconds = uptime / 1000;
@@ -16,4 +25,26 @@ public class Utils {
         uptimeHours %= 24;
         return String.format("%d days, %d hours, %d minutes, %d seconds", uptimeDays, uptimeHours, uptimeMinutes, uptimeSeconds);
     }
+
+    public String decimalFormat(double number) {
+        return df.format(number);
+    }
+
+    public String decimalFormat(long number) {
+        return df.format(number);
+    }
+
+    public String decimalFormat(int number) {
+        return df.format(number);
+    }
+
+    public String decimalFormat(float number) {
+        return df.format(number);
+    }
+
+    public String decimalFormat(short number) {
+        return df.format(number);
+    }
+
+
 }


### PR DESCRIPTION
Added the following features

- Discord Status Cycling
- Server Data
- Parent Server ID
- /reload command for Parent Server

## Parent Server
This is a configuration value in `TymeConfig` called `parent-server-id`, which essentially means the "parent" server which could be the main support server. It could have custom parent-server-specific commands and features.

I added a `/reload` command only for the parent server to reload the configuration from the Discord client.

## Discord Status Cycling
This is a cool system I developed recently which allows the Discord Bot to cycle through different statuses. I made this system so you can easily do that.

In `TymeConfig` we have two additional configuration values. `discord-status-interval` which is a simple integer value which represents how long the current iteration of the Discord status should persist for. When changing this value a restart of the bot is **required**. We also have another one called `statuses` which represents all the statuses possible to cycle.

## Server Data
This represents server specific custom data, it can hold custom data for the specific server if you wish to make anything specific to a server. The data object is called `DiscordServer`, the implementation class is `DiscordServerImpl`, and you can grab a Guild's `DiscordServer` instance through `ServerManager`.